### PR TITLE
生スコアに関するコメントを修正

### DIFF
--- a/src/beam.rs
+++ b/src/beam.rs
@@ -66,7 +66,7 @@ pub trait SmallState {
         self.raw_score()
     }
 
-    // 生スコア（大きいほど良い）
+    // 生スコア
     fn raw_score(&self) -> Self::Score;
 
     /// ハッシュ値


### PR DESCRIPTION
ビームサーチの「生スコア」は問題のスコアそのままの値であると定義し直した。